### PR TITLE
Update to swift version 6 and use vapor testing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "e00687f2d8251f4c5b9739b90b443e5a3a0505d63bf1c93119fe1e238fc1e9a1",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "78db67e5bf4a8543075787f228e8920097319281",
-        "version" : "1.18.0"
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
       }
     },
     {
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/async-kit.git",
       "state" : {
-        "revision" : "a61da00d404ec91d12766f1b9aac7d90777b484d",
-        "version" : "1.17.0"
+        "revision" : "6bbb83cbf9d886623a967a965c8fb1b73e6566f9",
+        "version" : "1.22.0"
       }
     },
     {
@@ -23,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",
       "state" : {
-        "revision" : "447f1046fb4e9df40973fe426ecb24a6f0e8d3b4",
-        "version" : "4.6.0"
+        "revision" : "32ad16dfc7677b927b225595ed18f3debb32f577",
+        "version" : "4.16.0"
       }
     },
     {
@@ -32,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent.git",
       "state" : {
-        "revision" : "4b4d8bf15a06fd60137e9c543e5503c4b842654e",
-        "version" : "4.8.0"
+        "revision" : "2fe9e36daf4bdb5edcf193e0d0806ba2074d2864",
+        "version" : "4.13.0"
       }
     },
     {
@@ -41,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent-kit.git",
       "state" : {
-        "revision" : "2d7dce5cb04156eecdb17e7349f4eac4206e8a17",
-        "version" : "1.42.4"
+        "revision" : "ec094096d715593c4944cb9aeb72a633faa82918",
+        "version" : "1.56.0"
       }
     },
     {
@@ -50,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent-sqlite-driver.git",
       "state" : {
-        "revision" : "33e920bd53c9a3a77f82733aaf26a82495afddd4",
-        "version" : "4.4.0"
+        "revision" : "e227d94dc3fe7099a096ac2ca28cad1f69bd8d5b",
+        "version" : "4.9.0"
       }
     },
     {
@@ -59,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/leaf.git",
       "state" : {
-        "revision" : "6fe0e843c6599f5189e45c7b08739ebc5c410c3b",
-        "version" : "4.2.4"
+        "revision" : "b70a6108e4917f338f6b8848407bf655aa7e405f",
+        "version" : "4.5.1"
       }
     },
     {
@@ -68,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/leaf-kit.git",
       "state" : {
-        "revision" : "13f2fc4c8479113cd23876d9a434ef4573e368bb",
-        "version" : "1.10.2"
+        "revision" : "6044b844caa858a0c5f2505ac166f5a057c990dc",
+        "version" : "1.14.2"
       }
     },
     {
@@ -77,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/multipart-kit.git",
       "state" : {
-        "revision" : "1adfd69df2da08f7931d4281b257475e32c96734",
-        "version" : "4.5.4"
+        "revision" : "3498e60218e6003894ff95192d756e238c01f44e",
+        "version" : "4.7.1"
       }
     },
     {
@@ -86,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/queues.git",
       "state" : {
-        "revision" : "f1adaf4c925eb7074a4acf363172c1fa6ec888c8",
-        "version" : "1.12.1"
+        "revision" : "4fa1ef91821fee04cce1982ba053ab37b88abfb9",
+        "version" : "1.18.0"
       }
     },
     {
@@ -95,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/routing-kit.git",
       "state" : {
-        "revision" : "611bc45c5dfb1f54b84d99b89d1f72191fb6b71b",
-        "version" : "4.7.2"
+        "revision" : "1a10ccea61e4248effd23b6e814999ce7bdf0ee0",
+        "version" : "4.9.3"
       }
     },
     {
@@ -104,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sql-kit.git",
       "state" : {
-        "revision" : "5026e7c0f2e464ea1af9f5948701aa8922ab14eb",
-        "version" : "3.27.0"
+        "revision" : "3779cedb44b1f374f2cca261c6d28f206024a582",
+        "version" : "3.36.0"
       }
     },
     {
@@ -113,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sqlite-kit.git",
       "state" : {
-        "revision" : "f66ddded9a330454856f5ba272cccc9e0c995b17",
-        "version" : "4.3.0"
+        "revision" : "f35a863ecc2da5d563b836a9a696b148b0f4169f",
+        "version" : "4.5.2"
       }
     },
     {
@@ -122,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sqlite-nio.git",
       "state" : {
-        "revision" : "2b7bcf3d2e4d2f68d52a66d12d2057867cee383a",
-        "version" : "1.5.2"
+        "revision" : "f08ed5a6c8ea205121cb698465f9af0ffc955995",
+        "version" : "1.12.7"
       }
     },
     {
@@ -131,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-algorithms.git",
       "state" : {
-        "revision" : "b14b7f4c528c942f121c8b860b9410b2bf57825e",
-        "version" : "1.0.0"
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
       }
     },
     {
@@ -140,8 +141,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a53d9f676cbc84ccc1643cf559a470ee5732ebb6",
-        "version" : "0.8.0"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
       }
     },
     {
@@ -149,17 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
-        "version" : "1.1.0"
-      }
-    },
-    {
-      "identity" : "swift-backtrace",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-backtrace.git",
-      "state" : {
-        "revision" : "f25620d5d05e2f1ba27154b40cafea2b67566956",
-        "version" : "1.3.3"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -167,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "9099e78aad1693ce5a2e5b108d8e1337fbff433b",
-        "version" : "0.6.0"
+        "revision" : "5aa1c0d1bc204908df47c2075bdbb39573d05e8d",
+        "version" : "1.19.0"
       }
     },
     {
@@ -176,8 +177,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
       }
     },
     {
@@ -185,8 +195,35 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "33a20e650c33f6d72d822d558333f2085effa3dc",
-        "version" : "2.5.0"
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
       }
     },
     {
@@ -194,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
-        "version" : "1.5.2"
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {
@@ -203,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "34025104068262db0cc998ace178975c5ff4f36b",
-        "version" : "2.4.0"
+        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
+        "version" : "2.10.1"
       }
     },
     {
@@ -212,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "6213ba7a06febe8fef60563a4a7d26a4085783cf",
-        "version" : "2.54.0"
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
       }
     },
     {
@@ -221,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "0e0d0aab665ff1a0659ce75ac003081f2b1c8997",
-        "version" : "1.19.0"
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
       }
     },
     {
@@ -230,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "a8ccf13fa62775277a5d56844878c828bbb3be1a",
-        "version" : "1.27.0"
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
       }
     },
     {
@@ -239,8 +276,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "e866a626e105042a6a72a870c88b4c531ba05f83",
-        "version" : "2.24.0"
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
       }
     },
     {
@@ -248,17 +285,44 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "41f4098903878418537020075a4d8a6e20a0b182",
-        "version" : "1.17.0"
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
       }
     },
     {
       "identity" : "swift-numerics",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
+      "location" : "https://github.com/apple/swift-numerics.git",
       "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
       }
     },
     {
@@ -266,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/unrelentingtech/SwiftCBOR.git",
       "state" : {
-        "revision" : "edc01765cf6b3685bb622bb09242ef5964fb991b",
-        "version" : "0.4.6"
+        "revision" : "fd929a6d8f7651ce0f63fc99397fd5762358cc29",
+        "version" : "0.6.0"
       }
     },
     {
@@ -275,8 +339,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "9a340de4995e5a9dade4ff4c51cd2e6ae30c12d6",
-        "version" : "4.77.0"
+        "revision" : "cfd8f434843ac7850e2d97f46c1aa5ddb906cf1c",
+        "version" : "4.121.4"
       }
     },
     {
@@ -293,8 +357,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/webauthn-swift.git",
       "state" : {
-        "revision" : "0e97beb4c868725707f0239cf9b664423f226ee9",
-        "version" : "1.0.0-alpha.1"
+        "revision" : "909cf4193cde7d64196553c4245ab647a68aaaca",
+        "version" : "1.0.0-beta.1"
       }
     },
     {
@@ -302,10 +366,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/websocket-kit.git",
       "state" : {
-        "revision" : "53fe0639a98903858d0196b699720decb42aee7b",
-        "version" : "2.14.0"
+        "revision" : "90bbbdab3ede12c803cfbe91646f291c092517a3",
+        "version" : "2.16.2"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.8
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
     name: "PasskeyDemo",
     platforms: [
-       .macOS(.v12)
+       .macOS(.v14)
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
@@ -24,12 +24,6 @@ let package = Package(
                 .product(name: "Vapor", package: "vapor"),
                 .product(name: "WebAuthn", package: "webauthn-swift"),
                 .product(name: "QueuesFluentDriver", package: "vapor-queues-fluent-driver")
-            ],
-            swiftSettings: [
-                // Enable better optimizations when building in Release configuration. Despite the use of
-                // the `.unsafeFlags` construct required by SwiftPM, this flag is recommended for Release
-                // builds. See <https://github.com/swift-server/guides/blob/main/docs/building.md#building-for-production> for details.
-                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
             ]
         ),
         .executableTarget(name: "Run", dependencies: [.target(name: "App")]),

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .executableTarget(name: "Run", dependencies: [.target(name: "App")]),
         .testTarget(name: "AppTests", dependencies: [
             .target(name: "App"),
-            .product(name: "XCTVapor", package: "vapor"),
+            .product(name: "VaporTesting", package: "vapor"),
         ])
     ]
 )

--- a/Public/scripts/createAccount.js
+++ b/Public/scripts/createAccount.js
@@ -15,7 +15,7 @@ createAccountForm.addEventListener("submit", async function(event) {
         console.log(error);
         return;
     }
-    location.href = "/";
+    location.href = "/private";
 });
 
 

--- a/Public/scripts/createAccount.js
+++ b/Public/scripts/createAccount.js
@@ -15,7 +15,7 @@ createAccountForm.addEventListener("submit", async function(event) {
         console.log(error);
         return;
     }
-    location.href = "/private";
+    location.href = "/";
 });
 
 

--- a/Sources/App/Models/User.swift
+++ b/Sources/App/Models/User.swift
@@ -2,7 +2,7 @@ import Fluent
 import Vapor
 import WebAuthn
 
-final class User: Model, Content {
+final class User: Model, Content, @unchecked Sendable {
     static let schema: String = "users"
 
     @ID

--- a/Sources/App/Models/WebAuthnCredential.swift
+++ b/Sources/App/Models/WebAuthnCredential.swift
@@ -2,7 +2,7 @@ import Fluent
 import Vapor
 import WebAuthn
 
-final class WebAuthnCredential: Model, Content {
+final class WebAuthnCredential: Model, Content, @unchecked Sendable {
     static let schema = "webauth_credentals"
 
     @ID(custom: "id", generatedBy: .user)

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -6,7 +6,7 @@ import WebAuthn
 import QueuesFluentDriver
 
 // configures your application
-public func configure(_ app: Application) throws {
+public func configure(_ app: Application) async throws {
     // uncomment to serve files from /Public folder
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
 
@@ -31,7 +31,7 @@ public func configure(_ app: Application) throws {
 
     app.views.use(.leaf)
     app.webAuthn = WebAuthnManager(
-        config: WebAuthnManager.Config(
+        configuration: WebAuthnManager.Configuration(
             relyingPartyID: Environment.get("RP_ID") ?? "localhost",
             relyingPartyName: Environment.get("RP_DISPLAY_NAME") ?? "Vapor Passkey Demo",
             relyingPartyOrigin: Environment.get("RP_ORIGIN") ?? "http://localhost:8080"
@@ -41,5 +41,5 @@ public func configure(_ app: Application) throws {
     // register routes
     try routes(app)
 
-    try app.autoMigrate().wait()
+    try await app.autoMigrate()
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -24,10 +24,7 @@ public func configure(_ app: Application) async throws {
     app.migrations.add(CreateWebAuthnCredential())
 
     app.queues.use(.fluent())
-    try app.queues.startInProcessJobs(on: .default)
-
     app.queues.schedule(DeleteUsersJob()).hourly().at(0)
-    try app.queues.startScheduledJobs()
 
     app.views.use(.leaf)
     app.webAuthn = WebAuthnManager(
@@ -42,4 +39,7 @@ public func configure(_ app: Application) async throws {
     try routes(app)
 
     try await app.autoMigrate()
+
+    try app.queues.startInProcessJobs(on: .default)
+    try app.queues.startScheduledJobs()
 }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -111,8 +111,6 @@ func routes(_ app: Application) throws {
         // If the credential was verified, save it to the database
         try await WebAuthnCredential(from: credential, userID: user.requireID()).save(on: req.db)
 
-        req.auth.logout(User.self)
-        req.session.destroy()
         return .ok
     }
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -111,12 +111,14 @@ func routes(_ app: Application) throws {
         // If the credential was verified, save it to the database
         try await WebAuthnCredential(from: credential, userID: user.requireID()).save(on: req.db)
 
+        req.auth.logout(User.self)
+        req.session.destroy()
         return .ok
     }
 
     // step 1 for authentication
     authSessionRoutes.get("authenticate") { req -> PublicKeyCredentialRequestOptions in
-        let options = try req.webAuthn.beginAuthentication()
+        let options = req.webAuthn.beginAuthentication()
 
         req.session.data["authChallenge"] = Data(options.challenge).base64EncodedString()
 
@@ -163,7 +165,7 @@ func routes(_ app: Application) throws {
     }
 }
 
-extension PublicKeyCredentialCreationOptions: AsyncResponseEncodable {
+extension PublicKeyCredentialCreationOptions: @retroactive AsyncResponseEncodable {
     public func encodeResponse(for request: Request) async throws -> Response {
         var headers = HTTPHeaders()
         headers.contentType = .json
@@ -171,7 +173,7 @@ extension PublicKeyCredentialCreationOptions: AsyncResponseEncodable {
     }
 }
 
-extension PublicKeyCredentialRequestOptions: AsyncResponseEncodable {
+extension PublicKeyCredentialRequestOptions: @retroactive AsyncResponseEncodable {
     public func encodeResponse(for request: Request) async throws -> Response {
         var headers = HTTPHeaders()
         headers.contentType = .json

--- a/Sources/Run/main.swift
+++ b/Sources/Run/main.swift
@@ -1,9 +1,20 @@
 import App
+import Logging
+import NIOCore
+import NIOPosix
 import Vapor
 
 var env = try Environment.detect()
 try LoggingSystem.bootstrap(from: &env)
-let app = Application(env)
-defer { app.shutdown() }
-try configure(app)
-try app.run()
+let app = try await Application.make(env)
+
+do {
+    try await configure(app)
+} catch {
+    app.logger.report(error: error)
+    try? await app.asyncShutdown()
+    throw error
+}
+
+try await app.execute()
+try await app.asyncShutdown()

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -1,14 +1,140 @@
+import Testing
 @testable import App
-import XCTVapor
+import VaporTesting
 
-final class AppTests: XCTestCase {
-    func testIndex() throws {
-        let app = Application(.testing)
-        defer { app.shutdown() }
-        try configure(app)
+@Suite(.serialized)
+struct AppTests {
 
-        try app.test(.GET, "", afterResponse: { res in
-            XCTAssertEqual(res.status, .ok)
-        })
+    private func sessionCookie(from response: TestingHTTPResponse) -> String {
+        response.headers.first(name: "Set-Cookie")
+            .flatMap { $0.split(separator: ";").first.map(String.init) }
+            ?? ""
+    }
+
+    // MARK: - Public routes
+
+    @Test func index() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(.GET, "/") { res async in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+
+    @Test func appleAppSiteAssociation() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(.GET, "/.well-known/apple-app-site-association") { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.contentType?.type == "application")
+                #expect(res.headers.contentType?.subType == "json")
+            }
+        }
+    }
+
+    // MARK: - Auth-protected routes
+
+    @Test func privateRedirectsWhenUnauthenticated() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(.GET, "/private") { res async in
+                #expect(res.status == .seeOther)
+                #expect(res.headers.first(name: "Location") == "/")
+            }
+        }
+    }
+
+    @Test func makeCredentialRequiresAuth() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(.GET, "/makeCredential") { res async in
+                #expect(res.status == .unauthorized)
+            }
+        }
+    }
+
+    // MARK: - Signup
+
+    @Test func signupCreatesUserAndRedirects() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(.GET, "/signup?username=\(UUID().uuidString)") { res async in
+                #expect(res.status == .seeOther)
+                #expect(res.headers.first(name: "Location") == "makeCredential")
+            }
+        }
+    }
+
+    @Test func signupRejectsDuplicateUsername() async throws {
+        try await withApp(configure: configure) { app in
+            let tester = try app.testing()
+            let username = UUID().uuidString
+
+            try await tester.test(.GET, "/signup?username=\(username)") { res async in
+                #expect(res.status == .seeOther)
+            }
+            try await tester.test(.GET, "/signup?username=\(username)") { res async in
+                #expect(res.status == .conflict)
+            }
+        }
+    }
+
+    // MARK: - Registration flow
+
+    @Test func makeCredentialReturnsOptionsWhenAuthenticated() async throws {
+        try await withApp(configure: configure) { app in
+            let tester = try app.testing()
+            let signupRes = try await tester.sendRequest(.GET, "/signup?username=\(UUID().uuidString)")
+            let cookie = sessionCookie(from: signupRes)
+
+            try await tester.test(.GET, "/makeCredential", beforeRequest: { req in
+                req.headers.add(name: "Cookie", value: cookie)
+            }, afterResponse: { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.contentType?.type == "application")
+                #expect(res.headers.contentType?.subType == "json")
+            })
+        }
+    }
+
+    // MARK: - Authentication
+
+    @Test func beginAuthenticationReturnsChallenge() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(.GET, "/authenticate") { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.contentType?.type == "application")
+                #expect(res.headers.contentType?.subType == "json")
+                #expect(res.body.string.contains("\"challenge\""))
+            }
+        }
+    }
+
+    // MARK: - Logout
+
+    @Test func logoutDestroysSession() async throws {
+        try await withApp(configure: configure) { app in
+            let tester = try app.testing()
+            let signupRes = try await tester.sendRequest(.GET, "/signup?username=\(UUID().uuidString)")
+            let cookie = sessionCookie(from: signupRes)
+
+            // Confirm the session is active
+            try await tester.test(.GET, "/makeCredential", beforeRequest: { req in
+                req.headers.add(name: "Cookie", value: cookie)
+            }, afterResponse: { res async in
+                #expect(res.status == .ok)
+            })
+
+            // Log out
+            try await tester.test(.POST, "/logout", beforeRequest: { req in
+                req.headers.add(name: "Cookie", value: cookie)
+            }, afterResponse: { res async in
+                #expect(res.status == .seeOther)
+                #expect(res.headers.first(name: "Location") == "/")
+            })
+
+            // The old session cookie should no longer authenticate
+            try await tester.test(.GET, "/makeCredential", beforeRequest: { req in
+                req.headers.add(name: "Cookie", value: cookie)
+            }, afterResponse: { res async in
+                #expect(res.status == .unauthorized)
+            })
+        }
     }
 }


### PR DESCRIPTION
1. Update to swift version 6.3.1.
2. Update tests to use VaporTesting and swift testing.
3. Extend test coverage.
4. Minor change to keep user logged-out after passkey-creation.
5. Fix order of migrations and job-queuing.
